### PR TITLE
First test of more sophisticated timing function

### DIFF
--- a/bg.js
+++ b/bg.js
@@ -1,0 +1,17 @@
+//Listens for messages from content scripts
+chrome.runtime.onMessage.addListener(function(request, sender) {
+    if(request.action == "checkPlaying") {
+        var tabName = request.tabName;
+
+        //Find tab object from the playing tab (by its title)
+        chrome.tabs.query({title: tabName}, function(tabs) {
+            if(tabs.length > 0) {
+                //Send a response if there is audio playing or not
+                chrome.tabs.sendMessage(tabs[0].id, {action: "checkPlayingResponse", response: tabs[0].audible});
+            }
+        });
+    }
+});
+
+
+

--- a/bg.js
+++ b/bg.js
@@ -1,13 +1,13 @@
 //Listens for messages from content scripts
 chrome.runtime.onMessage.addListener(function(request, sender) {
-    if(request.action == "checkPlaying") {
+    if(request.action == "checkAudioPlaying") {
         var tabName = request.tabName;
 
         //Find tab object from the playing tab (by its title)
         chrome.tabs.query({title: tabName}, function(tabs) {
             if(tabs.length > 0) {
                 //Send a response if there is audio playing or not
-                chrome.tabs.sendMessage(tabs[0].id, {action: "checkPlayingResponse", response: tabs[0].audible});
+                chrome.tabs.sendMessage(tabs[0].id, {action: "audioPlayingResponse", response: tabs[0].audible});
             }
         });
     }

--- a/bg.js
+++ b/bg.js
@@ -1,15 +1,11 @@
 //Listens for messages from content scripts
 chrome.runtime.onMessage.addListener(function(request, sender) {
     if(request.action == "checkAudioPlaying") {
-        var tabName = request.tabName;
 
-        //Find tab object from the playing tab (by its title)
-        chrome.tabs.query({title: tabName}, function(tabs) {
-            if(tabs.length > 0) {
-                //Send a response if there is audio playing or not
-                chrome.tabs.sendMessage(tabs[0].id, {action: "audioPlayingResponse", response: tabs[0].audible});
-            }
-        });
+        var tab = sender.tab;
+
+        //Send a response if there is audio playing or not
+        chrome.tabs.sendMessage(tab.id, {action: "audioPlayingResponse", response: tab.audible});
     }
 });
 

--- a/helpers.js
+++ b/helpers.js
@@ -35,6 +35,7 @@ function scrobbleAnime(animeId, episode) {
             };
         fetch(url, options);
         $('#anilist_scrobbler_notice').text('Anilist Scrobbler : L\'épisode a été ajouté à votre liste.');
+        clearInterval();
     });
 }
 
@@ -222,18 +223,26 @@ var progressionTimer;
 
 /* Timer class */
 function Timer(callback, delay, ...params) {
-    var timerId, start, remaining = delay;
+    var timerId, start, remaining = delay, paused;
 
     this.pause = function() {
         window.clearTimeout(timerId);
         remaining -= new Date() - start;
+        paused = true;
     };
 
     this.resume = function() {
         start = new Date();
         window.clearTimeout(timerId);
-        timerId = window.setTimeout(callback, remaining, params);
+        timerId = window.setTimeout(callback, remaining, ...params);
+        paused = false;
     };
+
+    this.isPaused = function() { return paused; };
+
+    this.getRemaining = function() { return remaining; };
+
+    this.setRemaining = function(time) { remaining = time; };
 
     this.resume();
 }
@@ -254,11 +263,15 @@ chrome.runtime.onMessage.addListener(function(request, sender) {
 
         /* Pause timer if nothing is playing, and resume it if it started again */
         if(!isPlaying) {
-            console.log("Timer paused!");
-            progressionTimer.pause();
+            if(!progressionTimer.isPaused()) {
+                console.log("Timer paused!");
+                progressionTimer.pause();
+            }
         } else {
-            console.log("Timer resumed!");
-            progressionTimer.resume();
+            if(progressionTimer.isPaused()) {
+                console.log("Timer resumed!");
+                progressionTimer.resume();
+            }
         }
     }
 });

--- a/helpers.js
+++ b/helpers.js
@@ -328,7 +328,7 @@ function initScrobble(series_title, episode_number, prepend_message) {
                             //instead of setTimeout, create a new Timer object and save it to a variable */
                             progressionTimer = new Timer(scrobbleAnime, duration / 4 * 3 * 60 * 1000, result.data.Page.media[anime_choose].id, episode_number);
                             //Also set an interval to check periodically if anything is playing
-                            setInterval(checkPlayingStatus, interval_delay);
+                            checkInterval = setInterval(checkPlayingStatus, interval_delay);
                         } else {
                             if (episode_number <= result2.data.Page.media[0].mediaListEntry.progress) {
                                 $('#anilist_scrobbler_notice').text(chrome.i18n.getMessage("appName") + ' : ' + chrome.i18n.getMessage("already_watched"));

--- a/helpers.js
+++ b/helpers.js
@@ -35,7 +35,7 @@ function scrobbleAnime(animeId, episode) {
             };
         fetch(url, options);
         $('#anilist_scrobbler_notice').text('Anilist Scrobbler : L\'épisode a été ajouté à votre liste.');
-        clearInterval();
+        clearInterval(checkInterval);
     });
 }
 
@@ -220,6 +220,9 @@ function chooseAnime(result, series_title) {
 
 /* Reference to the pausable/resumable timer */
 var progressionTimer;
+/* Reference to the interval used to check the playing status */
+var checkInterval;
+var interval_delay = 5000;
 
 /* Timer class */
 function Timer(callback, delay, ...params) {
@@ -325,18 +328,18 @@ function initScrobble(series_title, episode_number, prepend_message) {
                             //instead of setTimeout, create a new Timer object and save it to a variable */
                             progressionTimer = new Timer(scrobbleAnime, duration / 4 * 3 * 60 * 1000, result.data.Page.media[anime_choose].id, episode_number);
                             //Also set an interval to check periodically if anything is playing
-                            setInterval(checkPlayingStatus, 5000);
+                            setInterval(checkPlayingStatus, interval_delay);
                         } else {
                             if (episode_number <= result2.data.Page.media[0].mediaListEntry.progress) {
                                 $('#anilist_scrobbler_notice').text(chrome.i18n.getMessage("appName") + ' : ' + chrome.i18n.getMessage("already_watched"));
                             } else if (episode_number == result2.data.Page.media[0].mediaListEntry.progress + 1) {
                                 $('#anilist_scrobbler_notice').text(chrome.i18n.getMessage("appName") + ' : ' + chrome.i18n.getMessage("scrobbling_in_normal", [(duration / 4 * 3)]));
                                 progressionTimer = new Timer(scrobbleAnime, duration / 4 * 3 * 60 * 1000, result.data.Page.media[anime_choose].id, episode_number);
-                                setInterval(checkPlayingStatus, 5000);
+                                checkInterval = setInterval(checkPlayingStatus, interval_delay);
                             } else if (episode_number >= result2.data.Page.media[0].mediaListEntry.progress + 1) {
                                 $('#anilist_scrobbler_notice').text(chrome.i18n.getMessage("appName") + ' : ' + chrome.i18n.getMessage("scrobbling_in_jumped", [(duration / 4 * 3)]));
                                 progressionTimer = new Timer(scrobbleAnime, duration / 4 * 3 * 60 * 1000, result.data.Page.media[anime_choose].id, episode_number);
-                                setInterval(checkPlayingStatus, 5000);
+                                checkInterval = setInterval(checkPlayingStatus, interval_delay);
                             } else {
                                 console.error("Ehhhh....");
                             };

--- a/helpers.js
+++ b/helpers.js
@@ -252,26 +252,22 @@ function checkPlayingStatus() {
     console.log("checking playing status now");
 
     //send message to background script so that it can check the playing status of the current tab
-    chrome.runtime.sendMessage({action: "checkPlaying", tabName: document.title});
+    chrome.runtime.sendMessage({action: "checkAudioPlaying", tabName: document.title});
 }
 
 /* Listens for response from background script */
 chrome.runtime.onMessage.addListener(function(request, sender) { 
-    if(request.action == "checkPlayingResponse") {
+    if(request.action == "audioPlayingResponse") {
 
-        var isPlaying = request.response;
+        var audioPlaying = request.response;
 
         /* Pause timer if nothing is playing, and resume it if it started again */
-        if(!isPlaying) {
-            if(!progressionTimer.isPaused()) {
+        if(!audioPlaying && !progressionTimer.isPaused()) {
                 console.log("Timer paused!");
                 progressionTimer.pause();
-            }
-        } else {
-            if(progressionTimer.isPaused()) {
+        } else if(audioPlaying && progressionTimer.isPaused()) {
                 console.log("Timer resumed!");
                 progressionTimer.resume();
-            }
         }
     }
 });

--- a/helpers.js
+++ b/helpers.js
@@ -255,7 +255,7 @@ function checkPlayingStatus() {
     console.log("checking playing status now");
 
     //send message to background script so that it can check the playing status of the current tab
-    chrome.runtime.sendMessage({action: "checkAudioPlaying", tabName: document.title});
+    chrome.runtime.sendMessage({action: "checkAudioPlaying"});
 }
 
 /* Listens for response from background script */

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,8 @@
         "*://www.hulu.com/*",
         "*://www.netflix.com/*",
         "storage",
-        "notifications"
+        "notifications",
+        "tabs"
     ],
     "options_page": "options.html",
     "default_locale": "en",
@@ -25,7 +26,7 @@
         }
     },
     "background": {
-        "scripts": ["jquery.js", "updater.js"]
+        "scripts": ["jquery.js", "updater.js", "bg.js"]
     },
     "browser_action": {
         "default_icon": "img/logo_al.png",


### PR DESCRIPTION
As I wrote in the issue, it might be useful to have the extension automatically react
to the user pausing the video, or more generally, not watching it at all. If the tab just stays open for 15 minutes, the scrobbler shouldn't go and scrobble the new episode, since the user didn't watch it.

I tried to get something like that to work here. Basically what it does is, that it replaces the
old setTimeout function by a Timer object (class definition is also in the code). This timer can be paused and resumed with the respective functions. It also adds an interval that calls the function "checkPlayingStatus" every 5 seconds.

This function in turn then sends a message to the background script bg.js (since chrome.tabs isn't available in content scripts), which then checks the tab for playing audio, and sends a response back to the content script, that can then finally pause or resume the timer accordingly.

This is tested with Crunchyroll only, I dont have anything else ;)
As far as I can see it, the code should work on any site, not just Crunchyroll.
Theoretically, it works on any anime site that has audio playing (well, duh),
and a distinctive title. I went with distinction by title for now, but perhaps we may
be able to somehow get the tab id in the content script already and pass that instead of the title.
Not so sure about that, though. So in the current codebase, if you had 3 tabs playing netflix and netflix only ever had one and the same tab title, this would only update the first tab. But that alone is pretty unlikely, don't you think? ;)

Of course this is just a proof of concept, so feel free to optimize it.

